### PR TITLE
feat(spotdl): mirror Spotify playlists into Navidrome with sync + m3u

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ flowchart TB
 | [rdt-client](https://github.com/rogerfar/rdt-client) | Real-Debrid download client (Sonarr/Radarr) | — |
 | [Seerr](https://github.com/seerr/seerr) | Media request & discovery manager | — |
 | [Navidrome](https://www.navidrome.org) | Music streaming server | — |
-| [SpotDL](https://spotdl.readthedocs.io) | Spotify music downloader (CronJob onto shared media PVC) | — |
+| [SpotDL](https://spotdl.readthedocs.io) | Spotify playlist mirror (CronJob; syncs adds/removals and exports .m3u8 playlists Navidrome auto-imports) | — |
 
 ## ⚙️ Platform Services
 

--- a/apps/base/navidrome/deployment.yaml
+++ b/apps/base/navidrome/deployment.yaml
@@ -52,6 +52,14 @@ spec:
             - containerPort: 4533
               protocol: TCP
 
+          env:
+            # spotdl's CronJob writes one <playlist>.m3u8 per Spotify playlist
+            # into the music root; auto-import turns each into a Navidrome
+            # playlist that follows the file on every scan (order + removals).
+            # true is the default — set explicitly because spotdl relies on it.
+            - name: ND_AUTOIMPORTPLAYLISTS
+              value: "true"
+
           securityContext:
             allowPrivilegeEscalation: false
 

--- a/apps/base/spotdl/cronjob.yaml
+++ b/apps/base/spotdl/cronjob.yaml
@@ -53,15 +53,42 @@ spec:
               # v4.5.0: no /app/.venv — the image entrypoint is `uv run ... spotdl`,
               # replicated here so the playlist loop still works. Default audio
               # provider (ytmusic via yt-dlp) replaces the dead `piped` fallback.
+              #
+              # `sync` (not `download`) mirrors each Spotify playlist: first run
+              # downloads everything and records the track list in a .spotdl
+              # save file; later runs re-fetch the playlist, download additions,
+              # and DELETE local files for removed tracks. spotdl refuses
+              # --save-file together with a .spotdl query, hence the if/else.
+              #
+              # Everything is relative to the music root (cd below) on purpose:
+              # the same output template is written into the .m3u8, so entries
+              # stay relative and resolve inside Navidrome too, which mounts
+              # this dir at /music and auto-imports the .m3u8 files as
+              # playlists (Spotify order preserved, updated on every scan).
+              # Per-playlist folders keep sync deletions from clobbering a
+              # song that another playlist still references.
               command:
                 - /bin/sh
                 - -c
                 - |
-                  while IFS= read -r line; do
-                    [ -z "$line" ] && continue
-                    uv run --project /app --no-dev --frozen --no-sync \
-                      spotdl --output /data/media/music download "$line"
+                  cd /data/media/music
+                  mkdir -p .spotdl
+                  fail=0
+                  while IFS= read -r url; do
+                    [ -z "$url" ] && continue
+                    id=$(basename "$url" | cut -d'?' -f1)
+                    save=".spotdl/$id.spotdl"
+                    if [ -f "$save" ]; then
+                      set -- sync "$save"
+                    else
+                      set -- --save-file "$save" sync "$url"
+                    fi
+                    uv run --project /app --no-dev --frozen --no-sync spotdl \
+                      --output "{list-name}/{artists} - {title}.{output-ext}" \
+                      --m3u "{list}.m3u8" \
+                      "$@" || { echo "sync failed for $url"; fail=1; }
                   done < /config/playlist.txt
+                  exit $fail
 
               volumeMounts:
                 - name: data


### PR DESCRIPTION
## Summary
- **spotdl CronJob now uses `sync` instead of `download`** — each playlist in the ConfigMap gets a `.spotdl` save file under `/data/media/music/.spotdl/`; subsequent nightly runs download new tracks and **delete tracks that were removed from the Spotify playlist**.
- **Per-playlist folders + M3U export** — songs land in `<Playlist Name>/Artist - Title.mp3` and each run regenerates `<Playlist Name>.m3u8` at the music root in Spotify order, with relative entry paths.
- **Navidrome auto-imports the m3u files as playlists** (it mounts the same tree at `/music`; relative paths resolve on both sides). `ND_AUTOIMPORTPLAYLISTS=true` set explicitly to document the dependency. Imported playlists follow the file on every scan: order updates and removals propagate.

## Validation
- `sync` save-file semantics confirmed from `/app/spotdl/console/sync.py` in the pinned nightly image (first run: `sync <url> --save-file`; later runs: `sync <file>` — it errors if both are combined, hence the if/else in the script).
- M3U generation exercised in-container: `{list}.m3u8` filename templating, relative sanitized entries matching download paths.
- Live metadata fetch of the configured Top 50 Malaysia playlist (50 songs, `list_name` resolved) via the no-API SpotipyFree path.
- `kustomize build apps/staging` passes; cron script passes `sh -n`.

## Notes
- First run after merge re-downloads everything into the new per-playlist folders; files previously downloaded flat into `/data/media/music/` are orphans and can be cleaned up manually.
- Two chart playlists sharing a track store it once per playlist folder — intentional, so a removal in one playlist can never break the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)