### PR TITLE
docs(readme): move SpotDL into media stack diagram, add scripts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ flowchart TB
             direction LR
             N8N["🔧 n8n\nAutomation"]
             FLARE["🛡 FlareSolverr\nCF Bypass"]
-            SPOTDL["🎶 SpotDL\nSpotify DL"]
         end
 
         subgraph MEDIA["🎬 Media Stack (urial-lab)"]
@@ -103,6 +102,7 @@ flowchart TB
             PROWLARR["🔍 Prowlarr\nIndexer"]
             RDT["☁️ rdt-client\nReal-Debrid"]
             SEERR["🔎 Seerr\nRequest Manager"]
+            SPOTDL["🎶 SpotDL\nSpotify Sync"]
         end
 
         subgraph APPS["📦 User Applications"]
@@ -156,6 +156,7 @@ flowchart TB
     PROWLARR -. "Indexers" .-> SONARR
     PROWLARR -. "Indexers" .-> RADARR
     RDT -. "Downloads" .-> JELLY
+    SPOTDL -. "Playlists + .m3u8" .-> NAVI
 
     %% Inter-service
     FLARE -. "Proxy for scraping" .-> SUWA
@@ -236,6 +237,14 @@ These workloads exist in the repo but are commented out of their Kustomization (
 - Prometheus Operator via `kube-prometheus-stack`
 - Dashboards in Grafana
 - Alerting via Alertmanager
+
+---
+
+## 🧰 Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/homarr-seed.py` | Seeds the Homarr dashboard (apps, layout) via its REST API — Homarr boards live in its database, not in Git, so this script makes the dashboard reproducible. Run it against a port-forward, not the Cloudflare tunnel. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Move the SpotDL node from **Platform Services** into the **Media Stack** subgraph in the architecture diagram (it lives in the `movietime` namespace) and add a `SpotDL → Navidrome` edge for the playlist/.m3u8 sync
- Add a **Scripts** section documenting `scripts/homarr-seed.py` (Homarr boards are DB-backed, not GitOps — the script makes the dashboard reproducible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)