### PR TITLE
fix(renovate): prefer IPv4 DNS results — v6 lookups abort every run

### DIFF
--- a/infrastructure/controllers/base/renovate/configmap.yaml
+++ b/infrastructure/controllers/base/renovate/configmap.yaml
@@ -4,6 +4,10 @@ metadata:
   name: renovate-configmap
   namespace: renovate
 data:
+  # Pods have no IPv6 egress (Cilium is single-stack v4) but CoreDNS returns
+  # AAAA records first, so Node.js dials v6, times out on index.docker.io and
+  # Renovate aborts the whole run with external-host-error.
+  NODE_OPTIONS: "--dns-result-order=ipv4first"
   RENOVATE_AUTODISCOVER: "false"
   RENOVATE_GIT_AUTHOR: "Haiqal's Renovate Bot <bot@renovateapp.com>"
   RENOVATE_PLATFORM: "github"


### PR DESCRIPTION
## Problem
Every hourly Renovate run since ~Jun 30 aborts with `external-host-error` (`ETIMEDOUT` on `https://index.docker.io/v2/`), so **no dependency PRs have been opened since #141** — including the pending Sonarr 4.0.19 bump.

## Root cause
CoreDNS returns AAAA records first for Docker Hub, and pods have no IPv6 egress (Cilium is single-stack IPv4 — the LAN got IPv6 recently but the pod network didn't). Node.js inside the Renovate container dials IPv6, times out, and Renovate treats it as a fatal host error and skips the repo.

Verified with curl test pods on both nodes:
- `curl -4 https://index.docker.io/v2/` → 401 (connects fine)
- `curl -6 https://index.docker.io/v2/` → connect failure on both `hippo-lab` and `urial-lab`

## Fix
Add `NODE_OPTIONS: "--dns-result-order=ipv4first"` to `renovate-configmap` so Node resolves IPv4 first. Takes effect on the next hourly CronJob run after Flux reconciles.

## Expected result
Renovate resumes opening update PRs (Sonarr `4.0.19.2979-ls317`, Radarr `-ls308`, Prowlarr `-ls152` rebuilds, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)