### PR TITLE
fix(renovate): add memory limits — unbounded run OOMed urial-lab

### DIFF
--- a/infrastructure/controllers/base/renovate/configmap.yaml
+++ b/infrastructure/controllers/base/renovate/configmap.yaml
@@ -7,7 +7,9 @@ data:
   # Pods have no IPv6 egress (Cilium is single-stack v4) but CoreDNS returns
   # AAAA records first, so Node.js dials v6, times out on index.docker.io and
   # Renovate aborts the whole run with external-host-error.
-  NODE_OPTIONS: "--dns-result-order=ipv4first"
+  # max-old-space-size keeps the V8 heap under the container's 3Gi limit so
+  # Node GCs instead of getting OOM-killed.
+  NODE_OPTIONS: "--dns-result-order=ipv4first --max-old-space-size=2560"
   RENOVATE_AUTODISCOVER: "false"
   RENOVATE_GIT_AUTHOR: "Haiqal's Renovate Bot <bot@renovateapp.com>"
   RENOVATE_PLATFORM: "github"

--- a/infrastructure/controllers/base/renovate/cronjob.yaml
+++ b/infrastructure/controllers/base/renovate/cronjob.yaml
@@ -22,4 +22,14 @@ spec:
                 - configMapRef:
                     name: renovate-configmap
 
+              # Unbounded (BestEffort) Renovate OOMed urial-lab on 2026-07-06:
+              # Talos OOMController SIGKILLed neighbouring pods and Longhorn
+              # volumes degraded. Keep the kill inside this container.
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+                limits:
+                  memory: 3Gi
+
           restartPolicy: Never


### PR DESCRIPTION
## Problem
The first fully-working Renovate run (after #146 fixed the IPv6 abort) ran as **BestEffort** (no resources) and exhausted urial-lab's memory. Talos OOMController logs (15:20–15:22 UTC today) show it SIGKILLing multiple pod cgroups; Longhorn volumes went degraded and Longhorn deleted attached workload pods, causing mass pod restarts across the node.

## Fix
- `cronjob.yaml`: add `requests: 250m/512Mi`, `limits: memory 3Gi` — an OOM now kills only the Renovate container
- `configmap.yaml`: append `--max-old-space-size=2560` to `NODE_OPTIONS` so V8 GCs under the cgroup limit instead of being OOM-killed

## Urgency
The CronJob is `@hourly` — every run repeats the full workload until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)