### PR TITLE
feat(spotdl): sync Viral 50 - Malaysia + Release Radar

### DIFF
--- a/apps/base/spotdl/configmap.yaml
+++ b/apps/base/spotdl/configmap.yaml
@@ -6,3 +6,4 @@ data:
   playlist.txt: |
     https://open.spotify.com/playlist/37i9dQZEVXbJlfUljuZExa
     https://open.spotify.com/playlist/37i9dQZF1DWWuGaVZsglfu
+    https://open.spotify.com/playlist/37i9dQZEVXbLRmg3qDbY1H

--- a/apps/base/spotdl/configmap.yaml
+++ b/apps/base/spotdl/configmap.yaml
@@ -7,3 +7,4 @@ data:
     https://open.spotify.com/playlist/37i9dQZEVXbJlfUljuZExa
     https://open.spotify.com/playlist/37i9dQZF1DWWuGaVZsglfu
     https://open.spotify.com/playlist/37i9dQZEVXbLRmg3qDbY1H
+    https://open.spotify.com/playlist/37i9dQZEVXbmDy2GkwSHVw


### PR DESCRIPTION
## What

Adds two playlists to the spotdl daily sync list, alongside the existing Top 50 - Malaysia and Hot Hits Malaysia:

- **Viral 50 - Malaysia** (`37i9dQZEVXbLRmg3qDbY1H`) — official daily viral chart
- **Release Radar** (`37i9dQZEVXbmDy2GkwSHVw`) — personal weekly new-release playlist

## Notes

- `sync` mode mirrors playlists: the viral chart churns fast, so `Viral 50 - Malaysia/` will turn over most of its contents weekly (same behavior as the existing Top 50 entry). **Release Radar replaces all ~30 tracks every Friday**, so last week's releases get deleted locally each week too.
- First run after merge downloads everything and writes the `.spotdl` save files + `.m3u8`s; Navidrome picks the playlists up on its next scan.
- ⚠️ **Release Radar may fail to sync**: the URL returns 404 for anonymous web access (personalized playlists require user auth since Spotify's late-2024 API lockdown), and spotdl runs headless with client-credentials only. The loop continues past a failed playlist, but the Job will exit non-zero and retry, so expect nightly failed-job noise if it doesn't work. If so: drop that line and use **New Music Friday Malaysia** (`37i9dQZF1DWZMWLrh2UzwC`) as a public alternative for new-release coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)