### PR TITLE
fix(spotdl): pin CronJob schedule to Asia/Kuala_Lumpur

### DIFF
--- a/apps/base/spotdl/cronjob.yaml
+++ b/apps/base/spotdl/cronjob.yaml
@@ -3,7 +3,8 @@ kind: CronJob
 metadata:
   name: spotdl-sync
 spec:
-  schedule: "0 3 * * *" # every day at 3am
+  schedule: "0 3 * * *" # every day at 3am MYT
+  timeZone: Asia/Kuala_Lumpur
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   jobTemplate:


### PR DESCRIPTION
Without `spec.timeZone`, the CronJob schedule is interpreted as UTC — the "3am" sync actually fired at **11:00 AM MYT**. Adding `timeZone: Asia/Kuala_Lumpur` makes it run at 3 AM local as the comment always claimed.

Side effect: the next run after merge is **tonight 03:00 MYT (2026-07-07)** instead of 11 AM — which is also the first run to include the Viral 50 + Release Radar playlists from #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)