### PR TITLE
feat(metrics-server): deploy metrics-server for compute usage metrics

### DIFF
--- a/infrastructure/controllers/base/metrics-server/kustomization.yaml
+++ b/infrastructure/controllers/base/metrics-server/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metrics-server
+resources:
+  - namespace.yaml
+  - release.yaml
+  - repository.yaml
+
+configMapGenerator:
+  - name: metrics-server-values
+    files:
+      - values.yaml=values.yaml
+
+configurations:
+  - kustomizeconfig.yaml

--- a/infrastructure/controllers/base/metrics-server/kustomizeconfig.yaml
+++ b/infrastructure/controllers/base/metrics-server/kustomizeconfig.yaml
@@ -1,0 +1,6 @@
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/infrastructure/controllers/base/metrics-server/namespace.yaml
+++ b/infrastructure/controllers/base/metrics-server/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metrics-server
+  labels:
+    app.kubernetes.io/component: monitoring

--- a/infrastructure/controllers/base/metrics-server/release.yaml
+++ b/infrastructure/controllers/base/metrics-server/release.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metrics-server
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: metrics-server
+      version: "3.13.1" # or latest
+      sourceRef:
+        kind: HelmRepository
+        name: metrics-server
+        namespace: metrics-server
+  valuesFrom:
+    - kind: ConfigMap
+      name: metrics-server-values

--- a/infrastructure/controllers/base/metrics-server/repository.yaml
+++ b/infrastructure/controllers/base/metrics-server/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metrics-server
+spec:
+  url: https://kubernetes-sigs.github.io/metrics-server/
+  interval: 1h

--- a/infrastructure/controllers/base/metrics-server/values.yaml
+++ b/infrastructure/controllers/base/metrics-server/values.yaml
@@ -1,0 +1,6 @@
+# Talos kubelet serving certs are self-signed, so metrics-server cannot verify
+# them over TLS. --kubelet-insecure-tls skips that verification (standard for
+# Talos). This is appended to the chart's defaultArgs (kubelet-preferred-
+# address-types=InternalIP,..., kubelet-use-node-status-port, metric-resolution=15s).
+args:
+  - --kubelet-insecure-tls

--- a/infrastructure/controllers/staging/kustomization.yaml
+++ b/infrastructure/controllers/staging/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - external-dns
   - n8n
   - immich
+  - metrics-server

--- a/infrastructure/controllers/staging/metrics-server/kustomization.yaml
+++ b/infrastructure/controllers/staging/metrics-server/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metrics-server
+resources:
+  - ../../base/metrics-server/


### PR DESCRIPTION
## What
Deploys **metrics-server** (chart `3.13.1` / app `v0.8.1`) as an infrastructure controller in a dedicated `metrics-server` namespace.

## Why
`kubectl top nodes` / `kubectl top pods` returned `Metrics API not available` — the `metrics.k8s.io` apiservice and metrics-server were never installed (only kube-state-metrics existed, which feeds Prometheus, not the metrics API). This restores live CPU/RAM usage visibility.

## Notes
- `--kubelet-insecure-tls` is set because Talos kubelet serving certs are self-signed (standard requirement for metrics-server on Talos).
- Follows the existing base+overlay HelmRelease pattern (mirrors `external-dns`).
- Registered in `infrastructure/controllers/staging/kustomization.yaml`.
- Renovate will track the chart version (`# or latest`).

## Verification after merge
```sh
flux get helmrelease -n metrics-server metrics-server
kubectl top nodes
kubectl top pods -A
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)