### PR TITLE
feat(suwayomi): cap JVM heap and add memory limit

### DIFF
--- a/apps/base/suwayomi/deployment.yaml
+++ b/apps/base/suwayomi/deployment.yaml
@@ -27,6 +27,16 @@ spec:
             - configMapRef:
                 name: suwayomi-configmap
 
+          # JVM heap is capped via JAVA_TOOL_OPTIONS=-Xmx512m (configmap). This
+          # limit is the hard backstop: 896Mi leaves headroom for JVM non-heap
+          # (metaspace, threads, direct buffers, code cache) above the 512Mi heap.
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              memory: 896Mi
+
           securityContext:
             allowPrivilegeEscalation: false
 

--- a/apps/staging/suwayomi/configmap.yaml
+++ b/apps/staging/suwayomi/configmap.yaml
@@ -7,3 +7,8 @@ data:
   TZ: "Etc/UTC"
   FLARESOLVERR_ENABLED: "true"
   FLARESOLVERR_URL: "http://flaresolverr.amdhql.org:8191"
+  # The image launches `java -jar ...` with no heap flag, so the JVM sizes its
+  # heap to a % of visible RAM. With no container limit it saw the whole node
+  # and ballooned to ~865Mi. The JVM auto-honors JAVA_TOOL_OPTIONS, so cap the
+  # heap here; the deployment's memory limit is the hard backstop.
+  JAVA_TOOL_OPTIONS: "-Xmx512m"


### PR DESCRIPTION
## What
Caps Suwayomi's memory so it stops ballooning:
- `JAVA_TOOL_OPTIONS: "-Xmx512m"` in the configmap — caps the JVM heap (auto-honored by the JVM; the image's startup script launches `java -jar` with no heap flag).
- `resources` on the deployment: `requests` 25m CPU / 256Mi, `limits.memory: 896Mi` as the hard backstop.

## Why
metrics-server (PR #162) revealed Suwayomi was the **#3 memory consumer in the whole cluster (~865Mi at 2m CPU)** — above immich and jellyfin. With no container limit, the JVM sized its heap against the *node's* full RAM (~13Gi → up to ~3.3Gi max heap) instead of what a manga reader needs. It runs on urial-lab, the memory-constrained node (76%).

## Effect
Steady-state RSS should settle ~600–700Mi (reclaiming ~150–250Mi) and hard-capped under 1Gi, freeing headroom on urial-lab.

## Verification after merge
```sh
flux reconcile kustomization apps --with-source
kubectl -n suwayomi rollout status deploy/suwayomi
kubectl top pod -n suwayomi
kubectl -n suwayomi logs deploy/suwayomi | grep "JAVA_TOOL_OPTIONS"   # JVM confirms pickup
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)