### PR TITLE
docs(omni): record kubelet image-GC config patch

### DIFF
--- a/omni/README.md
+++ b/omni/README.md
@@ -1,0 +1,36 @@
+# Omni Config Patches
+
+Talos **machine-config** patches for the `Talos-Pineapple` cluster, managed by
+[Sidero Omni](https://omni.siderolabs.io/) — **not** by FluxCD.
+
+> ⚠️ FluxCD reconciles Kubernetes workloads (this repo's `apps/`,
+> `infrastructure/`, etc.). It does **not** manage Talos OS / node
+> configuration. Node-level config (kubelet args, mounts, NTP, hostnames) lives
+> in Omni. The files here are a **version-controlled reference** of the patches
+> applied out-of-band via `omnictl`; Omni remains the source of truth.
+
+## Applying
+
+```sh
+# Requires an authenticated omnictl (browser SSO against the Omni instance).
+omnictl apply -f omni/config-patches/<patch>.yaml          # create/update
+omnictl apply -f omni/config-patches/<patch>.yaml --dry-run # preview
+omnictl get configpatch                                     # list live patches
+```
+
+Patch IDs are prefixed with a weight (`500-` = normal user weight). A patch is
+bound by label: `omni.sidero.dev/cluster: <cluster>` (cluster-wide) or
+`omni.sidero.dev/machine: <machine-id>` (single node).
+
+Machine IDs:
+
+| Machine ID | Node | Role |
+|---|---|---|
+| `03000200-0400-0500-0006-000700080009` | urial-lab | worker |
+| `43126e8a-4c7b-95ef-a96c-8e0b615bcb3c` | hippo-lab | control-plane |
+
+## Patches
+
+| File | Scope | What |
+|---|---|---|
+| `config-patches/500-kubelet-image-gc.yaml` | cluster | Lowers kubelet image-GC thresholds (high 70 / low 45) so unused container images from Renovate tag churn are auto-pruned. Added 2026-07-20 after ~546 GiB of orphaned image layers filled urial-lab. |

--- a/omni/config-patches/500-kubelet-image-gc.yaml
+++ b/omni/config-patches/500-kubelet-image-gc.yaml
@@ -1,0 +1,27 @@
+# Talos machine-config patch applied via Sidero Omni (NOT reconciled by FluxCD).
+# Apply/update with:  omnictl apply -f omni/config-patches/500-kubelet-image-gc.yaml
+#
+# Purpose: lower the kubelet image-garbage-collection thresholds so unused
+# container images are reclaimed. Renovate bumps image tags/digests constantly
+# (spotdl:nightly, etc.); each new pull orphans the old layers. The Talos
+# default thresholds (high 85% / low 80%) never fired because urial-lab's
+# ephemeral partition sat at ~81% — just under the trigger — so ~546 GiB of
+# orphaned image layers (2255 image refs) accumulated. Lowering high→70/low→45
+# lets kubelet auto-prune unused images; in-use images are never touched.
+# Scoped cluster-wide (harmless to hippo-lab at ~6% usage).
+metadata:
+    namespace: default
+    type: ConfigPatches.omni.sidero.dev
+    id: 500-kubelet-image-gc
+    labels:
+        omni.sidero.dev/cluster: Talos-Pineapple
+    annotations:
+        name: kubelet image GC threshold
+        description: Reclaim orphaned container images from Renovate tag churn. Default 85/80 never fired at 81% disk on urial-lab.
+spec:
+    data: |
+        machine:
+          kubelet:
+            extraConfig:
+              imageGCHighThresholdPercent: 70
+              imageGCLowThresholdPercent: 45


### PR DESCRIPTION
## What
Adds an `omni/` directory that records **Talos machine-config patches applied via Sidero Omni** (out-of-band, not reconciled by FluxCD):
- `omni/README.md` — explains the Omni-vs-Flux boundary, how to apply patches with `omnictl`, and the machine-ID → node map.
- `omni/config-patches/500-kubelet-image-gc.yaml` — the exact ConfigPatch applied.

## Why
Diagnosing urial-lab's disk pressure revealed it wasn't Longhorn snapshots (there were none) — it was **~546 GiB of orphaned container image layers** (2255 image refs) from Renovate constantly bumping tags/digests. Talos' default kubelet image-GC thresholds (high 85% / low 80%) never fired because the disk sat at ~81%, just under the trigger.

The applied patch lowers the thresholds to **high 70 / low 45**, so kubelet auto-prunes unused images (in-use images untouched). Committing it here keeps a reviewable record even though Omni is the source of truth.

## Not a Flux change
The `omni/` path is not referenced by any Flux Kustomization, so this has **zero cluster-reconcile impact** — it's documentation of an infra change made directly in Omni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)