### PR TITLE
chore(suwayomi): update image to v2.3.2243

### DIFF
--- a/apps/base/suwayomi/deployment.yaml
+++ b/apps/base/suwayomi/deployment.yaml
@@ -19,7 +19,7 @@ spec:
 
       containers:
         - name: suwayomi
-          image: ghcr.io/suwayomi/suwayomi-server:v2.2.2219
+          image: ghcr.io/suwayomi/suwayomi-server:v2.3.2243
           ports:
             - containerPort: 4567
 


### PR DESCRIPTION
## What

Bumps `ghcr.io/suwayomi/suwayomi-server` from `v2.2.2219` → **`v2.3.2243`** in `apps/base/suwayomi/deployment.yaml`.

| | Version | Date |
|---|---|---|
| Before | `v2.2.2219` | pinned 2026-06-28 (#138) |
| After | `v2.3.2243` | released 2026-07-13 |

This picks up the whole `v2.3` line — SyncYomi support, Extension API v1.6 — plus its four hotfixes.

## Why this was missed

`v2.3.2223` landed 2026-06-30, two days after #138 pinned `v2.2.2219`. Renovate never offered the update because the repo sat at Renovate's default `prConcurrentLimit` of 10 open PRs from 2026-07-16 onward, which stopped it opening new branches. The CronJob itself was healthy throughout. That limit is raised separately so this class of silent staleness doesn't recur.

## Version choice

`v2.3.2279` exists as a GHCR tag but is an untagged preview build, not a GitHub release. This pins the latest tagged release instead. Manifest verified present in GHCR (`sha256:e59f212c…`) so Flux won't hit `ImagePullBackOff`.

## Migration risk

First startup is expected to migrate the Tachidesk H2 database on `suwayomi-files-pvc` (library, categories, read progress). **Downgrading to 2.2 after that migration generally does not work.**

A Longhorn snapshot was taken before merging:

```
suwayomi-files-pre-v2-3-2243   1.6GiB   readyToUse: true   2026-07-27T16:09:15Z
```

⚠️ Caveat on that safety net: `pvc-81ee2bb5` is `degraded` — it requests `numberOfReplicas: 3` but only one replica is running (on `urial-lab`), which is expected on a 2-node cluster with Longhorn's default node anti-affinity. This is pre-existing, not caused by this change, but it means the snapshot and the live volume share one disk. If `urial-lab`'s disk fails, both are lost. A Longhorn backup to an external target would be real protection; the snapshot only covers a bad migration.

## Verification

- `kubectl kustomize apps/staging` renders the new tag cleanly
- GHCR manifest resolves, HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)