### PR TITLE
chore(renovate): raise PR limits and enable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 5,
   "flux": {
     "fileMatch": ["\\.yaml$"]
   },


### PR DESCRIPTION
## What

Adds three settings to `renovate.json`:

```json
"dependencyDashboard": true,
"prConcurrentLimit": 20,
"prHourlyLimit": 5,
```

## Why

Renovate had been silently rate-limited since **2026-07-16**. The config set no limits, so Renovate's defaults applied — `prConcurrentLimit: 10`, `prHourlyLimit: 2`. With #152–#161 open, the repo sat *exactly* on the 10-PR ceiling. Every hourly run could refresh existing branches but never open a new one.

The failure mode was quiet. The CronJob was healthy throughout (`renovate/renovate:43.246.1`, extracting 135 deps per run) and `renovate-configmap` overrides only platform/author/`NODE_OPTIONS`, so nothing looked wrong. Meanwhile Suwayomi missed the entire `v2.3` line released 2026-06-30 (fixed in #168) and no signal surfaced it. `dependencyDashboard` was off and the repo has zero issues, so the backlog had no visible representation anywhere.

Of the three settings, `dependencyDashboard` is the one that actually prevents recurrence — the limits just make the queue drain faster. A raised ceiling alone would have hidden the same problem for longer at a higher threshold.

## Confirmation from the logs

Yesterday #152, #158 and #159 merged, freeing three slots. The next runs then created exactly two PRs (#166 cilium, #167 n8n) — the hourly cap — putting the repo back to 9 open with one slot left. Consistent with limits being the binding constraint rather than lookup failures.

## Expected effect

A burst of PRs over the next few runs as the accumulated backlog clears, at 5/hour. That's the queue draining, not a malfunction.

One unrelated thing the logs surfaced, not addressed here: a recurring lookup failure worth its own fix.

```
WARN: Failed to look up docker package lscr.io/linuxserver/prowlarr: no-result
```

`apps/base/prowlarr/deployment.yaml` has not been getting update PRs at all as a result.

## Verification

- `renovate.json` parses as valid JSON
- Repo-only change; no cluster manifests touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)